### PR TITLE
Fix Info.plist error

### DIFF
--- a/PDFGenerator.podspec
+++ b/PDFGenerator.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/sgr-ksmt/PDFGenerator.git", :tag => s.version.to_s }
   s.platform         = :ios, '8.0'
   s.requires_arc     = true
-  s.source_files     = "PDFGenerator/**/*"
+  s.source_files     = "PDFGenerator/**/*.swift"
   s.frameworks   = 'WebKit'
 end

--- a/PDFGenerator.podspec
+++ b/PDFGenerator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PDFGenerator"
-  s.version          = "2.1"
+  s.version          = "2.1.1"
   s.summary          = "A simple PDF generator."
   s.homepage         = "https://github.com/sgr-ksmt/PDFGenerator"
   # s.screenshots     = ""


### PR DESCRIPTION
Fix the issue that may be raised by XCode when using CocoaPods installation method.

>Multiple commands produce '…/Products/Debug-iphonesimulator/PDFGenerator/PDFGenerator.framework/Info.plist':
>1) Target 'PDFGenerator' (project 'Pods') has copy command from '…/Pods/PDFGenerator/PDFGenerator/Info.plist' to '…/Build/Products/Debug-iphonesimulator/PDFGenerator/PDFGenerator.framework/Info.plist'
>2) Target 'PDFGenerator' (project 'Pods') has process command with output '…/Build/Products/Debug-iphonesimulator/PDFGenerator/PDFGenerator.framework/Info.plist'

We don't need to include `Info.plist` file in Pod.

_⚠️ Don't forget to tag PDFGenerator as 2.1.1 on pull request merge._